### PR TITLE
New Test Case: Verify seller name and buyer name displayed on messages screen

### DIFF
--- a/qa-testcases/manual/messages/TC-1759967765193-verify-seller-name-and-buyer-name-displayed-on-messages-screen.md
+++ b/qa-testcases/manual/messages/TC-1759967765193-verify-seller-name-and-buyer-name-displayed-on-messages-screen.md
@@ -1,0 +1,41 @@
+---
+title: "Verify seller name and buyer name displayed on messages screen"
+story_id: "MS-005"
+priority: "P3"
+suite: "Messages"
+component: "messages"
+preconditions: "seller name and buyer name\nmake sure to have login for two account to test this "
+data: "seller name and buyer namer user name and password"
+env: "Prod"
+status: "Draft"
+created: "2025-10-08T23:56:05.193Z"
+created_by: "nastradacha"
+---
+
+# Verify seller name and buyer name displayed on messages screen
+
+## Story Reference
+Story #MS-005
+
+## Preconditions
+seller name and buyer name
+make sure to have login for two account to test this 
+
+
+## Test Data
+seller name and buyer namer user name and password
+
+
+## Test Steps
+1. login to wazobialist.com with seller name and buyer name
+2. click messages
+3. check is seller name and buyer name is showing 
+
+## Expected Results
+seller name and buyer name should be showing 
+
+## Metadata
+- **Priority**: P3
+- **Suite**: Messages
+- **Component**: messages
+- **Environment**: Prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: MS-005
- **Priority**: P3
- **Suite**: Messages
- **Component**: messages
- **Folder**: manual/messages

## Description
This PR adds a new test case for review.

### Steps
1. login to wazobialist.com with seller name and buyer name
2. click messages
3. check is seller name and buyer name is showing 

### Expected Results
seller name and buyer name should be showing 