### PR TITLE
New Test Case: Verify listing title is displayed on each message card

### DIFF
--- a/qa-testcases/manual/messages/TC-012-verify-listing-title-is-displayed-on-each-message-.md
+++ b/qa-testcases/manual/messages/TC-012-verify-listing-title-is-displayed-on-each-message-.md
@@ -1,0 +1,45 @@
+---
+title: "Verify listing title is displayed on each message card"
+story_id: "MS-005"
+priority: "P3"
+suite: "Messages"
+component: "Message"
+preconditions: |
+  - listings available 
+  - conversations available between buyers and seller
+steps: |
+  1. login to wazobialist.com
+  2. click messages tab
+  3. Verify listing title displayed on each message card
+expected: "- listing title displayed on each message card"
+env: "prod"
+status: "Draft"
+created: "2025-10-11T15:57:34.647Z"
+created_by: "nastradacha"
+---
+
+# Verify listing title is displayed on each message card
+
+## Story Reference
+Story #MS-005
+
+## Preconditions
+- listings available 
+- conversations available between buyers and seller
+
+
+
+
+## Test Steps
+1. login to wazobialist.com
+2. click messages tab
+3. Verify listing title displayed on each message card
+
+## Expected Results
+- listing title displayed on each message card
+
+## Metadata
+- **Priority**: P3
+- **Suite**: Messages
+- **Component**: Message
+- **Environment**: prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: MS-005
- **Priority**: P3
- **Suite**: Messages
- **Component**: Message
- **Folder**: manual/messages

## Description
This PR adds a new test case for review.

### Steps
1. login to wazobialist.com
2. click messages tab
3. Verify listing title displayed on each message card

### Expected Results
- listing title displayed on each message card