### PR TITLE
New Test Case: Verify that buyer's offer amount badge is displayed on the message card

### DIFF
--- a/qa-testcases/manual/messages/TC-014-verify-that-buyer-s-offer-amount-badge-is-displaye.md
+++ b/qa-testcases/manual/messages/TC-014-verify-that-buyer-s-offer-amount-badge-is-displaye.md
@@ -1,0 +1,47 @@
+---
+title: "Verify that buyer's offer amount badge is displayed on the message card"
+story_id: "MS-005"
+priority: "P2"
+suite: "Messages"
+component: "Message"
+preconditions: "- log in with two accounts"
+data: "test2"
+steps: |
+  1. login to wazobialist.com with buyer and seller
+  2. send offer to seller
+  3. go to seller message tab
+  4. buyer's offer amount badge is displayed on the message card  in naira
+expected: "- buyer's offer amount badge should displayed on the message card  in naira"
+env: "prod"
+status: "Draft"
+created: "2025-10-11T17:27:27.460Z"
+created_by: "nastradacha"
+---
+
+# Verify that buyer's offer amount badge is displayed on the message card
+
+## Story Reference
+Story #MS-005
+
+## Preconditions
+- log in with two accounts
+
+
+## Test Data
+test2
+
+
+## Test Steps
+1. login to wazobialist.com with buyer and seller
+2. send offer to seller
+3. go to seller message tab
+4. buyer's offer amount badge is displayed on the message card  in naira
+
+## Expected Results
+- buyer's offer amount badge should displayed on the message card  in naira
+
+## Metadata
+- **Priority**: P2
+- **Suite**: Messages
+- **Component**: Message
+- **Environment**: prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: MS-005
- **Priority**: P2
- **Suite**: Messages
- **Component**: Message
- **Folder**: manual/messages

## Description
This PR adds a new test case for review.

### Steps
1. login to wazobialist.com with buyer and seller
2. send offer to seller
3. go to seller message tab
4. buyer's offer amount badge is displayed on the message card  in naira

### Expected Results
- buyer's offer amount badge should displayed on the message card  in naira