### PR TITLE
New Test Case: Verify Accepted badge is displayed to buyer when the seller accepts the offer

### DIFF
--- a/qa-testcases/manual/messages/TC-015-verify-accepted-badge-is-displayed-to-buyer-when-t.md
+++ b/qa-testcases/manual/messages/TC-015-verify-accepted-badge-is-displayed-to-buyer-when-t.md
@@ -1,0 +1,46 @@
+---
+title: "Verify Accepted badge is displayed to buyer when the seller accepts the offer"
+story_id: "MS-005"
+priority: "P3"
+suite: "Messages"
+component: "Message"
+preconditions: "- login as buyer and seller"
+steps: |
+  1. login to wazobialist.com as buyer and seller
+  2. create a new listing as seller
+  3. login as buyer and send an offer for that listing
+  4. go the sellers messages and accept offer
+  5. go to buyers messages and to see the accepted badge
+expected: "- Accepted badge is displayed to buyer when the seller accepts the offer"
+env: "prod"
+status: "Draft"
+created: "2025-10-11T17:40:26.919Z"
+created_by: "nastradacha"
+---
+
+# Verify Accepted badge is displayed to buyer when the seller accepts the offer
+
+## Story Reference
+Story #MS-005
+
+## Preconditions
+- login as buyer and seller
+
+
+
+
+## Test Steps
+1. login to wazobialist.com as buyer and seller
+2. create a new listing as seller
+3. login as buyer and send an offer for that listing
+4. go the sellers messages and accept offer
+5. go to buyers messages and to see the accepted badge
+
+## Expected Results
+- Accepted badge is displayed to buyer when the seller accepts the offer
+
+## Metadata
+- **Priority**: P3
+- **Suite**: Messages
+- **Component**: Message
+- **Environment**: prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: MS-005
- **Priority**: P3
- **Suite**: Messages
- **Component**: Message
- **Folder**: manual/messages

## Description
This PR adds a new test case for review.

### Steps
1. login to wazobialist.com as buyer and seller
2. create a new listing as seller
3. login as buyer and send an offer for that listing
4. go the sellers messages and accept offer
5. go to buyers messages and to see the accepted badge

### Expected Results
- Accepted badge is displayed to buyer when the seller accepts the offer