### PR TITLE
New Test Case: Verify press-and-hold reveals password temporarily

### DIFF
--- a/qa-testcases/manual/Reveal/Hide Password Functionality/TC-040-verify-press-and-hold-reveals-password-temporarily.md
+++ b/qa-testcases/manual/Reveal/Hide Password Functionality/TC-040-verify-press-and-hold-reveals-password-temporarily.md
@@ -4,13 +4,12 @@ story_id: "US-012 Password eye toggle"
 priority: "P2"
 suite: "General"
 steps: |
-  1. Navigate to the login page.   
-  2. Enter a valid password in the password field. 
-  3. Press and hold the “eye” icon.
 expected: "- Password text becomes visible while pressing and holding.  Once the icon is released, the password should immediately be re-masked."
 status: "Draft"
 created: "2025-11-10T08:27:56.502Z"
 created_by: "QUDUS07"
+updated_by: QUDUS07
+updated: 2025-11-12T14:01:07.637Z
 ---
 
 # Verify press-and-hold reveals password temporarily
@@ -25,7 +24,7 @@ Story #US-012 Password eye toggle
 ## Test Steps
 1. Navigate to the login page.   
 2. Enter a valid password in the password field. 
-3. Press and hold the “eye” icon.
+3. Press and hold the âeyeâ icon.
 
 ## Expected Results
 - Password text becomes visible while pressing and holding.  Once the icon is released, the password should immediately be re-masked.


### PR DESCRIPTION
## Test Case Details

- **Story ID**: US-012 Password eye toggle
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Reveal/Hide Password Functionality

## Description
This PR adds a new test case for review.

### Steps
1. Navigate to the login page.   
2. Enter a valid password in the password field. 
3. Press and hold the “eye” icon.

### Expected Results
- Password text becomes visible while pressing and holding.  Once the icon is released, the password should immediately be re-masked.