### PR TITLE
New Test Case: Verify release of press re-masks password immediately

### DIFF
--- a/qa-testcases/manual/Reveal/Hide Password Functionality/TC-041-verify-release-of-press-re-masks-password-immediat.md
+++ b/qa-testcases/manual/Reveal/Hide Password Functionality/TC-041-verify-release-of-press-re-masks-password-immediat.md
@@ -1,0 +1,39 @@
+---
+title: "Verify release of press re-masks password immediately"
+story_id: "#135"
+priority: "P2"
+suite: "General"
+steps: |
+  1. Press and hold the eye icon to reveal the password.  
+  2. Release the press.
+expected: |
+  - Password instantly hides (re-masks).
+  - Password remains hidden afterward.
+env: "prod"
+status: "Draft"
+created: "2025-11-10T08:39:12.494Z"
+created_by: "QUDUS07"
+---
+
+# Verify release of press re-masks password immediately
+
+## Story Reference
+Story ##135
+
+
+
+
+
+## Test Steps
+1. Press and hold the eye icon to reveal the password.  
+2. Release the press.
+
+## Expected Results
+- Password instantly hides (re-masks).
+- Password remains hidden afterward.
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+- **Environment**: prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: #135
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Reveal/Hide Password Functionality

## Description
This PR adds a new test case for review.

### Steps
1. Press and hold the eye icon to reveal the password.  
2. Release the press.

### Expected Results
- Password instantly hides (re-masks).
- Password remains hidden afterward.