### PR TITLE
New Test Case: Verify click (persistent) reveals password for up to 15 seconds

### DIFF
--- a/qa-testcases/manual/Reveal/Hide Password Functionality/TC-042-verify-click-persistent-reveals-password-for-up-to.md
+++ b/qa-testcases/manual/Reveal/Hide Password Functionality/TC-042-verify-click-persistent-reveals-password-for-up-to.md
@@ -1,0 +1,39 @@
+---
+title: "Verify click (persistent) reveals password for up to 15 seconds"
+story_id: "#135"
+priority: "P2"
+suite: "General"
+steps: |
+  1. On the register page, enter a password. 
+  2.  Click the eye icon once (without holding).
+expected: |
+  - Password becomes visible.
+  - Remains visible for up to 15 seconds or until user clicks outside the field.
+env: "prod"
+status: "Draft"
+created: "2025-11-10T08:42:21.775Z"
+created_by: "QUDUS07"
+---
+
+# Verify click (persistent) reveals password for up to 15 seconds
+
+## Story Reference
+Story ##135
+
+
+
+
+
+## Test Steps
+1. On the register page, enter a password. 
+2.  Click the eye icon once (without holding).
+
+## Expected Results
+- Password becomes visible.
+- Remains visible for up to 15 seconds or until user clicks outside the field.
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+- **Environment**: prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: #135
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Reveal/Hide Password Functionality

## Description
This PR adds a new test case for review.

### Steps
1. On the register page, enter a password. 
2.  Click the eye icon once (without holding).

### Expected Results
- Password becomes visible.
- Remains visible for up to 15 seconds or until user clicks outside the field.