### PR TITLE
New Test Case: Verify password re-masks when user clicks outside the field (blur event)

### DIFF
--- a/qa-testcases/manual/Reveal/Hide Password Functionality/TC-044-verify-password-re-masks-when-user-clicks-outside-.md
+++ b/qa-testcases/manual/Reveal/Hide Password Functionality/TC-044-verify-password-re-masks-when-user-clicks-outside-.md
@@ -1,0 +1,35 @@
+---
+title: "Verify password re-masks when user clicks outside the field (blur event)"
+story_id: "135"
+priority: "P2"
+suite: "General"
+steps: |
+  1. Click once to reveal the password.  
+  2. Click anywhere outside the password input field before 15 seconds.
+expected: "- Password is re-masked immediately."
+status: "Draft"
+created: "2025-11-10T08:57:28.264Z"
+created_by: "QUDUS07"
+---
+
+# Verify password re-masks when user clicks outside the field (blur event)
+
+## Story Reference
+Story #135
+
+
+
+
+
+## Test Steps
+1. Click once to reveal the password.  
+2. Click anywhere outside the password input field before 15 seconds.
+
+## Expected Results
+- Password is re-masked immediately.
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+


### PR DESCRIPTION
## Test Case Details

- **Story ID**: 135
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Reveal/Hide Password Functionality

## Description
This PR adds a new test case for review.

### Steps
1. Click once to reveal the password.  
2. Click anywhere outside the password input field before 15 seconds.

### Expected Results
- Password is re-masked immediately.