### PR TITLE
New Test Case: Verify password automatically re-masks after 15 seconds

### DIFF
--- a/qa-testcases/manual/Reveal/Hide Password Functionality/TC-045-verify-password-automatically-re-masks-after-15-se.md
+++ b/qa-testcases/manual/Reveal/Hide Password Functionality/TC-045-verify-password-automatically-re-masks-after-15-se.md
@@ -1,0 +1,35 @@
+---
+title: "Verify password automatically re-masks after 15 seconds"
+story_id: "135"
+priority: "P2"
+suite: "General"
+steps: |
+  1. Click the eye icon once to reveal password.  
+  2. Do not click outside or interact for 15 seconds.
+expected: "- After 15 seconds, password automatically hides."
+status: "Draft"
+created: "2025-11-10T08:59:06.313Z"
+created_by: "QUDUS07"
+---
+
+# Verify password automatically re-masks after 15 seconds
+
+## Story Reference
+Story #135
+
+
+
+
+
+## Test Steps
+1. Click the eye icon once to reveal password.  
+2. Do not click outside or interact for 15 seconds.
+
+## Expected Results
+- After 15 seconds, password automatically hides.
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+


### PR DESCRIPTION
## Test Case Details

- **Story ID**: 135
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Reveal/Hide Password Functionality

## Description
This PR adds a new test case for review.

### Steps
1. Click the eye icon once to reveal password.  
2. Do not click outside or interact for 15 seconds.

### Expected Results
- After 15 seconds, password automatically hides.