### PR TITLE
New Test Case: Verify reveal/hide works consistently on both login and register pages

### DIFF
--- a/qa-testcases/manual/Reveal/Hide Password Functionality/TC-046-verify-reveal-hide-works-consistently-on-both-logi.md
+++ b/qa-testcases/manual/Reveal/Hide Password Functionality/TC-046-verify-reveal-hide-works-consistently-on-both-logi.md
@@ -1,0 +1,33 @@
+---
+title: "Verify reveal/hide works consistently on both login and register pages"
+story_id: "135"
+priority: "P2"
+suite: "General"
+steps: "1. Perform the press-and-hold and click tests on both login and register pages."
+expected: "- Behavior should be consistent across both pages (same timing, icon, and masking behavior)."
+env: "Prod"
+status: "Draft"
+created: "2025-11-10T09:10:36.669Z"
+created_by: "QUDUS07"
+---
+
+# Verify reveal/hide works consistently on both login and register pages
+
+## Story Reference
+Story #135
+
+
+
+
+
+## Test Steps
+1. Perform the press-and-hold and click tests on both login and register pages.
+
+## Expected Results
+- Behavior should be consistent across both pages (same timing, icon, and masking behavior).
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+- **Environment**: Prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: 135
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Reveal/Hide Password Functionality

## Description
This PR adds a new test case for review.

### Steps
1. Perform the press-and-hold and click tests on both login and register pages.

### Expected Results
- Behavior should be consistent across both pages (same timing, icon, and masking behavior).