### PR TITLE
New Test Case: Verify password field remains secure (not visible in page source or copyable while masked)

### DIFF
--- a/qa-testcases/manual/Reveal/Hide Password Functionality/TC-047-verify-password-field-remains-secure-not-visible-i.md
+++ b/qa-testcases/manual/Reveal/Hide Password Functionality/TC-047-verify-password-field-remains-secure-not-visible-i.md
@@ -1,0 +1,33 @@
+---
+title: "Verify password field remains secure (not visible in page source or copyable while masked)"
+story_id: "135"
+priority: "P2"
+suite: "General"
+steps: "1. While password is masked, attempt to copy or inspect password element."
+expected: "- Password is not visible or retrievable from page source or developer tools when masked."
+env: "prod"
+status: "Draft"
+created: "2025-11-10T09:12:27.280Z"
+created_by: "QUDUS07"
+---
+
+# Verify password field remains secure (not visible in page source or copyable while masked)
+
+## Story Reference
+Story #135
+
+
+
+
+
+## Test Steps
+1. While password is masked, attempt to copy or inspect password element.
+
+## Expected Results
+- Password is not visible or retrievable from page source or developer tools when masked.
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+- **Environment**: prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: 135
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Reveal/Hide Password Functionality

## Description
This PR adds a new test case for review.

### Steps
1. While password is masked, attempt to copy or inspect password element.

### Expected Results
- Password is not visible or retrievable from page source or developer tools when masked.