### PR TITLE
New Test Case: Ensure CAC verification only runs when business details exist.

### DIFF
--- a/qa-testcases/manual/CAC background check for shops/TC-063-ensure-cac-verification-only-runs-when-business-de.md
+++ b/qa-testcases/manual/CAC background check for shops/TC-063-ensure-cac-verification-only-runs-when-business-de.md
@@ -1,0 +1,45 @@
+---
+title: "Ensure CAC verification only runs when business details exist."
+story_id: "136"
+priority: "P2"
+suite: "General"
+steps: |
+  1. Create a user without business_name or RC number
+  2. Submit verification
+  3. View verification details in admin
+expected: |
+  CAC check is skipped
+  No CAC section shown
+  No record created in business_verifications
+  Admin sees standard verification status only
+env: "prod"
+status: "Draft"
+created: "2025-11-20T15:35:30.262Z"
+created_by: "QUDUS07"
+---
+
+# Ensure CAC verification only runs when business details exist.
+
+## Story Reference
+Story #136
+
+
+
+
+
+## Test Steps
+1. Create a user without business_name or RC number
+2. Submit verification
+3. View verification details in admin
+
+## Expected Results
+CAC check is skipped
+No CAC section shown
+No record created in business_verifications
+Admin sees standard verification status only
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+- **Environment**: prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: 136
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/CAC background check for shops

## Description
This PR adds a new test case for review.

### Steps
1. Create a user without business_name or RC number
2. Submit verification
3. View verification details in admin

### Expected Results
CAC check is skipped
No CAC section shown
No record created in business_verifications
Admin sees standard verification status only