### PR TITLE
New Test Case: Validate Manifest Loads in DevTools

### DIFF
--- a/qa-testcases/manual/Web Manifest Validity & Linking/TC-065-validate-manifest-loads-in-devtools.md
+++ b/qa-testcases/manual/Web Manifest Validity & Linking/TC-065-validate-manifest-loads-in-devtools.md
@@ -1,0 +1,59 @@
+---
+title: "Validate Manifest Loads in DevTools"
+story_id: "146"
+priority: "P2"
+suite: "General"
+preconditions: |
+  App is running on a secure origin (HTTPS)
+  Manifest is linked in <head> via <link rel="manifest" href="/manifest.json">
+  Access to desktop Chrome DevTools
+  Access to Android Chrome
+  No service worker is required for this test (PWA-002 covers that)
+steps: |
+  1. Open the application in Chrome
+  2. Open DevTools → Application → Manifest
+  3. Observe the manifest panel
+expected: |
+  No “Manifest could not be parsed” errors
+  Manifest URL correctly loaded
+  App name and short_name display as configured
+  theme_color and background_color fields show valid CSS colors
+  No missing required fields (name, icons, start_url, display)
+env: "Prod"
+status: "Draft"
+created: "2025-11-25T13:48:11.546Z"
+created_by: "QUDUS07"
+---
+
+# Validate Manifest Loads in DevTools
+
+## Story Reference
+Story #146
+
+## Preconditions
+App is running on a secure origin (HTTPS)
+Manifest is linked in <head> via <link rel="manifest" href="/manifest.json">
+Access to desktop Chrome DevTools
+Access to Android Chrome
+No service worker is required for this test (PWA-002 covers that)
+
+
+
+
+## Test Steps
+1. Open the application in Chrome
+2. Open DevTools → Application → Manifest
+3. Observe the manifest panel
+
+## Expected Results
+No “Manifest could not be parsed” errors
+Manifest URL correctly loaded
+App name and short_name display as configured
+theme_color and background_color fields show valid CSS colors
+No missing required fields (name, icons, start_url, display)
+
+## Metadata
+- **Priority**: P2
+- **Suite**: General
+
+- **Environment**: Prod


### PR DESCRIPTION
## Test Case Details

- **Story ID**: 146
- **Priority**: P2
- **Suite**: General
- **Folder**: manual/Web Manifest Validity & Linking

## Description
This PR adds a new test case for review.

### Steps
1. Open the application in Chrome
2. Open DevTools → Application → Manifest
3. Observe the manifest panel

### Expected Results
No “Manifest could not be parsed” errors
Manifest URL correctly loaded
App name and short_name display as configured
theme_color and background_color fields show valid CSS colors
No missing required fields (name, icons, start_url, display)